### PR TITLE
NS-14093 Remove customer email from front-end tagging

### DIFF
--- a/.github/workflows/ide.yml
+++ b/.github/workflows/ide.yml
@@ -44,7 +44,7 @@ jobs:
         docker run --rm \
           -v ${{ github.workspace }}:/data/project:ro \
           -v ${{ runner.temp }}/qodana:/data/results \
-          jetbrains/qodana-php:latest --print-problems
+          jetbrains/qodana-php-community:latest --print-problems
 
     - name: Archive inspection results
       if: always()

--- a/.github/workflows/ide.yml
+++ b/.github/workflows/ide.yml
@@ -9,33 +9,48 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+      - uses: actions/checkout@v1
 
-    ############################################################################
-    - name: Set up PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '7.2'
-        tools: composer, prestissimo, pecl
-        coverage: none
+      ############################################################################
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.2'
+          tools: composer, prestissimo, pecl
+          coverage: none
 
-      #https://github.com/actions/cache/blob/master/examples.md#php---composer
-    - name: Cache composer packages
-      id: composer-cache
-      run: |
-        composer config cache-files-dir
-        echo "::set-output name=dir::$(composer config cache-files-dir)"
-    - uses: actions/cache@v4
-      with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-
+        #https://github.com/actions/cache/blob/master/examples.md#php---composer
+      - name: Cache composer packages
+        id: composer-cache
+        run: |
+          composer config cache-files-dir
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
 
-    - name: Update project dependencies
-      run: |
-        composer install --prefer-dist --no-progress --no-suggest
-        composer dump-autoload --optimize
-        rm -rf libs/bin
-    ############################################################################
+      - name: Update project dependencies
+        run: |
+          composer install --prefer-dist --no-progress --no-suggest
+          composer dump-autoload --optimize
+          rm -rf libs/bin
+      ############################################################################
 
+      - name: Run PHPStorm
+        uses: supercid/action-phpstorm@master
+        with:
+          target: .
+          profile: ./.idea/inspectionProfiles/CI.xml
+          output: ./output
+          verbosity: v2
+          scope: Inspection
+
+      - name: Archive inspection results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: inspection-results
+          path: output

--- a/.github/workflows/ide.yml
+++ b/.github/workflows/ide.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Run Qodana (Code Inspection)
       uses: JetBrains/qodana-action@v2023.3
       with:
-        args: --baseline /dev/null
+        args: --print-problems
 
     - name: Archive inspection results
       if: always()

--- a/.github/workflows/ide.yml
+++ b/.github/workflows/ide.yml
@@ -40,7 +40,7 @@ jobs:
       ############################################################################
 
       - name: Run PHPStorm
-        uses: supercid/action-phpstorm@master
+        uses: Nosto/action-phpstorm@master
         with:
           target: .
           profile: ./.idea/inspectionProfiles/CI.xml

--- a/.github/workflows/ide.yml
+++ b/.github/workflows/ide.yml
@@ -39,16 +39,3 @@ jobs:
         rm -rf libs/bin
     ############################################################################
 
-    - name: Run Qodana (Code Inspection)
-      run: |
-        docker run --rm \
-          -v ${{ github.workspace }}:/data/project:ro \
-          -v ${{ runner.temp }}/qodana:/data/results \
-          jetbrains/qodana-php-community:latest --print-problems
-
-    - name: Archive inspection results
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: qodana-results
-        path: ${{ runner.temp }}/qodana/results

--- a/.github/workflows/ide.yml
+++ b/.github/workflows/ide.yml
@@ -39,18 +39,14 @@ jobs:
         rm -rf libs/bin
     ############################################################################
 
-    - name: Run PHPStorm
-      uses: supercid/action-phpstorm@master
+    - name: Run Qodana (Code Inspection)
+      uses: JetBrains/qodana-action@v2023.3
       with:
-        target: .
-        profile: ./.idea/inspectionProfiles/CI.xml
-        output: ./output
-        verbosity: v2
-        scope: Inspection
+        args: --baseline /dev/null
 
     - name: Archive inspection results
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: inspection-results
-        path: output
+        name: qodana-results
+        path: ${{ runner.temp }}/qodana/results

--- a/.github/workflows/ide.yml
+++ b/.github/workflows/ide.yml
@@ -40,9 +40,11 @@ jobs:
     ############################################################################
 
     - name: Run Qodana (Code Inspection)
-      uses: JetBrains/qodana-action@v2023.3
-      with:
-        args: --print-problems
+      run: |
+        docker run --rm \
+          -v ${{ github.workspace }}:/data/project:ro \
+          -v ${{ runner.temp }}/qodana:/data/results \
+          jetbrains/qodana-php:latest --print-problems
 
     - name: Archive inspection results
       if: always()

--- a/classes/models/NostoCustomer.php
+++ b/classes/models/NostoCustomer.php
@@ -42,7 +42,6 @@ class NostoCustomer extends NostoSDKCustomer
         $nostoCustomer = new NostoCustomer();
         $nostoCustomer->setFirstName($customer->firstname);
         $nostoCustomer->setLastName($customer->lastname);
-        $nostoCustomer->setEmail($customer->email);
         $nostoCustomer->setMarketingPermission($customer->newsletter);
         try {
             $nostoCustomer->populateCustomerReference($customer);

--- a/classes/models/order/NostoOrderBuyer.php
+++ b/classes/models/order/NostoOrderBuyer.php
@@ -43,7 +43,6 @@ class NostoOrderBuyer extends NostoSDKOrderBuyer
         $nostoBuyer = new NostoOrderBuyer();
         $nostoBuyer->setFirstName($customer->firstname);
         $nostoBuyer->setLastName($customer->lastname);
-        $nostoBuyer->setEmail($customer->email);
         $nostoBuyer->setMarketingPermission($customer->newsletter);
 
         $billingAddressId = $order->id_address_invoice;


### PR DESCRIPTION
Fixes data exposure issue where customer email addresses were being rendered in HTML and indexed by Google's crawler.

- Remove email from NostoCustomer front-end tagging
- Remove email from NostoOrderBuyer order confirmation tagging
- Customer reference (hashed ID) provides sufficient unique identification
- Email still available for backend/API operations

Fixes: [NS-14093](https://nostosolutions.atlassian.net/browse/NS-14093)

[NS-14093]: https://nostosolutions.atlassian.net/browse/NS-14093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ